### PR TITLE
fix: guard floating-base external position actuators

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1738,25 +1738,13 @@ class ModelBuilder:
         entry.output_indices.append(output_indices)
         entry.args.append(array_params)
 
-    @staticmethod
-    def _actuator_entry_uses_position_feedback(entry: ActuatorEntry) -> bool:
-        """Return whether an actuator entry reads joint position feedback."""
-        for args in entry.args:
-            if float(args.get("kp", 0.0)) != 0.0:
-                return True
-            if float(args.get("ki", 0.0)) != 0.0:
-                return True
-        return False
-
     def _validate_external_actuator_indexing(self) -> None:
         """Reject position-sensitive external actuators on joints without 1:1 q/qd indexing."""
         if not self.actuator_entries or self.joint_dof_count == 0:
             return
 
-        joint_q_start = copy.copy(self.joint_q_start)
-        joint_q_start.append(self.joint_coord_count)
-        joint_qd_start = copy.copy(self.joint_qd_start)
-        joint_qd_start.append(self.joint_dof_count)
+        joint_q_start = [*self.joint_q_start, self.joint_coord_count]
+        joint_qd_start = [*self.joint_qd_start, self.joint_dof_count]
 
         dof_to_joint = np.full(self.joint_dof_count, -1, dtype=np.int32)
         for joint_index, dof_start in enumerate(self.joint_qd_start):
@@ -1764,7 +1752,7 @@ class ModelBuilder:
             dof_to_joint[dof_start:dof_end] = joint_index
 
         for (actuator_class, _scalar_key), entry in self.actuator_entries.items():
-            if not self._actuator_entry_uses_position_feedback(entry):
+            if not any(float(args.get("kp", 0.0)) != 0.0 or float(args.get("ki", 0.0)) != 0.0 for args in entry.args):
                 continue
 
             for actuator_input_indices in entry.input_indices:

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1738,6 +1738,61 @@ class ModelBuilder:
         entry.output_indices.append(output_indices)
         entry.args.append(array_params)
 
+    @staticmethod
+    def _actuator_entry_uses_position_feedback(entry: ActuatorEntry) -> bool:
+        """Return whether an actuator entry reads joint position feedback."""
+        for args in entry.args:
+            if float(args.get("kp", 0.0)) != 0.0:
+                return True
+            if float(args.get("ki", 0.0)) != 0.0:
+                return True
+        return False
+
+    def _validate_external_actuator_indexing(self) -> None:
+        """Reject position-sensitive external actuators on joints without 1:1 q/qd indexing."""
+        if not self.actuator_entries or self.joint_dof_count == 0:
+            return
+
+        joint_q_start = copy.copy(self.joint_q_start)
+        joint_q_start.append(self.joint_coord_count)
+        joint_qd_start = copy.copy(self.joint_qd_start)
+        joint_qd_start.append(self.joint_dof_count)
+
+        dof_to_joint = np.full(self.joint_dof_count, -1, dtype=np.int32)
+        for joint_index, dof_start in enumerate(self.joint_qd_start):
+            dof_end = joint_qd_start[joint_index + 1]
+            dof_to_joint[dof_start:dof_end] = joint_index
+
+        for (actuator_class, _scalar_key), entry in self.actuator_entries.items():
+            if not self._actuator_entry_uses_position_feedback(entry):
+                continue
+
+            for actuator_input_indices in entry.input_indices:
+                for dof_index in actuator_input_indices:
+                    if dof_index < 0 or dof_index >= self.joint_dof_count:
+                        continue
+
+                    joint_index = int(dof_to_joint[dof_index])
+                    if joint_index < 0:
+                        continue
+
+                    q_start = joint_q_start[joint_index]
+                    qd_start = joint_qd_start[joint_index]
+                    coord_count = joint_q_start[joint_index + 1] - q_start
+                    dof_count = joint_qd_start[joint_index + 1] - qd_start
+                    if q_start == qd_start and coord_count == dof_count:
+                        continue
+
+                    joint_label = self.joint_label[joint_index]
+                    raise ValueError(
+                        f"{actuator_class.__name__} uses shared DOF input indices for position and velocity "
+                        f"feedback, but joint {joint_index} ('{joint_label}') has joint_q_start={q_start}, "
+                        f"joint_qd_start={qd_start}, joint_coord_count={coord_count}, "
+                        f"joint_dof_count={dof_count}. Position-sensitive external actuators currently require "
+                        f"1:1 joint_q/joint_qd indexing. Use kd-only velocity control, native joint drives, "
+                        f"or separate position/velocity index mappings."
+                    )
+
     def _stack_args_to_arrays(
         self,
         args_list: list[dict[str, Any]],
@@ -10297,6 +10352,7 @@ class ModelBuilder:
             )
 
             # Create actuators from accumulated entries
+            self._validate_external_actuator_indexing()
             m.actuators = []
             for (actuator_class, scalar_key), entry in self.actuator_entries.items():
                 input_indices = self._build_index_array(entry.input_indices, device)

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import numpy as np
 import warp as wp
 
+import newton
 from newton.actuators import (
     Actuator,
     ActuatorDCMotor,
@@ -102,6 +103,74 @@ class TestActuatorPDUnit(unittest.TestCase):
         self.assertEqual(resolved["kp"], 50.0)
         self.assertEqual(resolved["kd"], 0.0)
         self.assertEqual(resolved["constant_force"], 0.0)
+
+
+class TestExternalActuatorBuilderValidation(unittest.TestCase):
+    """Standalone builder regressions for external actuator indexing."""
+
+    def setUp(self):
+        wp.init()
+
+    @staticmethod
+    def _build_floating_base_chain() -> tuple[newton.ModelBuilder, int]:
+        builder = newton.ModelBuilder()
+        base = builder.add_link(label="base")
+        child = builder.add_link(label="child")
+        root = builder.add_joint_free(parent=-1, child=base, label="root")
+        hinge = builder.add_joint_revolute(parent=base, child=child, axis=(0.0, 0.0, 1.0), label="hinge")
+        builder.add_articulation([root, hinge], label="floating_robot")
+        return builder, hinge
+
+    def test_builder_rejects_position_feedback_on_floating_base_joint(self):
+        builder, hinge = self._build_floating_base_chain()
+        dof_index = builder.joint_qd_start[hinge]
+
+        self.assertNotEqual(builder.joint_q_start[hinge], dof_index)
+        builder.add_actuator(ActuatorPD, input_indices=[dof_index], kp=100.0, kd=0.0, max_force=200.0)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shared DOF input indices for position and velocity feedback",
+        ):
+            builder.finalize(device="cpu")
+
+    def test_builder_rejects_integral_feedback_on_floating_base_joint(self):
+        builder, hinge = self._build_floating_base_chain()
+        dof_index = builder.joint_qd_start[hinge]
+
+        builder.add_actuator(
+            ActuatorPID,
+            input_indices=[dof_index],
+            kp=0.0,
+            ki=1.0,
+            kd=0.0,
+            integral_max=10.0,
+            max_force=200.0,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shared DOF input indices for position and velocity feedback",
+        ):
+            builder.finalize(device="cpu")
+
+    def test_builder_allows_velocity_only_feedback_on_floating_base_joint(self):
+        builder, hinge = self._build_floating_base_chain()
+        dof_index = builder.joint_qd_start[hinge]
+
+        builder.add_actuator(ActuatorPD, input_indices=[dof_index], kp=0.0, kd=10.0, max_force=200.0)
+        builder.finalize(device="cpu")
+
+    def test_builder_allows_position_feedback_on_fixed_base_joint(self):
+        builder = newton.ModelBuilder()
+        child = builder.add_link(label="child")
+        hinge = builder.add_joint_revolute(parent=-1, child=child, axis=(0.0, 0.0, 1.0), label="hinge")
+        builder.add_articulation([hinge], label="fixed_robot")
+        dof_index = builder.joint_qd_start[hinge]
+
+        self.assertEqual(builder.joint_q_start[hinge], dof_index)
+        builder.add_actuator(ActuatorPD, input_indices=[dof_index], kp=100.0, kd=0.0, max_force=200.0)
+        builder.finalize(device="cpu")
 
 
 class TestActuatorDelayedPDUnit(unittest.TestCase):


### PR DESCRIPTION
## Summary
- reject external actuators that use position feedback (`kp` or `ki`) when their shared DOF indices do not map 1:1 between `joint_q` and `joint_qd`
- keep velocity-only external actuators working on floating-base articulations
- add standalone builder regressions for floating-base PD/PID indexing and fixed-base compatibility

The integrated actuator path still assumes one shared input index space for both position (`joint_q`) and velocity (`joint_qd`) feedback. That assumption breaks once an articulation contains joints where coordinates and velocities diverge, for example a free root joint or any other non-1:1 coordinate joint.

In those cases a downstream DOF index can be valid in `joint_qd` but shifted in `joint_q`, so position-sensitive external actuators read the wrong position slot. Velocity-only external actuators remain fine because they only read `joint_qd`.

A downstream example is a floating-base excavator model where a velocity-only turn actuator works, but steering-style position-sensitive external actuators do not. That example is only motivation here; the code and tests in this PR stay fully standalone.

## Scope
This keeps the fix narrow by adding a builder-side guard instead of changing the actuator API. A follow-up can add separate position and velocity index mappings for external actuators if we want full support for position-sensitive controllers on floating-base articulations.

## Validation
- `uv run --with pytest python -m pytest newton/tests/test_actuators.py -q`
- `uv run --with pytest python -m pytest newton/tests/test_selection.py -k 'empty_selection' -q`
- `uv run --with ruff ruff check newton/_src/sim/builder.py`
