### PR TITLE
Add actuator state position indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ### Fixed
 
+- Raise a clear migration error when legacy actuator classes do not accept `state_pos_indices`; switch imports to `newton.actuators`
 - Fix inertia validation spuriously inflating small but physically valid eigenvalues for lightweight components (< ~50 g) by using a relative threshold instead of an absolute 1e-6 cutoff
 - Restore keyboard camera movement while hovering gizmos so keyboard controls remain active when the pointer is over gizmos
 - Resolve USD asset references recursively in `resolve_usd_from_url` so nested stages are fully downloaded

--- a/docs/concepts/actuators.rst
+++ b/docs/concepts/actuators.rst
@@ -99,7 +99,9 @@ Stateful Actuators
 ^^^^^^^^^^^^^^^^^^
 
 Stateful actuators (PID, delayed, neural-network) require double-buffered
-state objects::
+state objects. Direct construction must pass ``state_pos_indices`` explicitly;
+builder-created actuators still infer it from ``input_indices`` when that
+mapping is unambiguous::
 
     from newton.actuators import ActuatorPID
 
@@ -107,6 +109,7 @@ state objects::
     pid_actuator = ActuatorPID(
         input_indices=indices,
         output_indices=indices,
+        state_pos_indices=indices,
         kp=wp.array([100.0, 100.0], dtype=wp.float32),
         ki=wp.array([10.0, 10.0], dtype=wp.float32),
         kd=wp.array([5.0, 5.0], dtype=wp.float32),

--- a/newton/_src/actuators/actuators/base.py
+++ b/newton/_src/actuators/actuators/base.py
@@ -47,17 +47,21 @@ class Actuator:
         self,
         input_indices: wp.array[wp.uint32],
         output_indices: wp.array[wp.uint32],
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         control_output_attr: str = "joint_f",
     ):
         """Initialize actuator.
 
         Args:
-            input_indices: DOF indices for reading state and targets.
+            input_indices: DOF indices for reading velocity state and targets.
                 Shape ``(N,)`` for single input per actuator, ``(N, M)`` for
                 multiple inputs per actuator.
             output_indices: DOF indices for writing output forces.
                 Shape ``(N,)`` for single output per actuator, ``(N, K)`` for
                 multiple outputs per actuator.
+            state_pos_indices: Optional coordinate indices for reading position
+                state. Defaults to *input_indices*.
             control_output_attr: Attribute name on :class:`~newton.Control` for output.
         """
         self.input_indices = input_indices
@@ -69,6 +73,16 @@ class Actuator:
             raise ValueError(
                 f"output_indices length ({len(output_indices)}) must match input_indices length ({self.num_actuators})"
             )
+
+        if state_pos_indices is None:
+            state_pos_indices = input_indices
+        if len(state_pos_indices) != self.num_actuators:
+            raise ValueError(
+                f"state_pos_indices length ({len(state_pos_indices)}) must match input_indices length "
+                f"({self.num_actuators})"
+            )
+
+        self.state_pos_indices = state_pos_indices
 
         device = input_indices.device
         self._sequential_indices = wp.array(np.arange(self.num_actuators, dtype=np.uint32), device=device)

--- a/newton/_src/actuators/actuators/dc_motor.py
+++ b/newton/_src/actuators/actuators/dc_motor.py
@@ -67,6 +67,8 @@ class ActuatorDCMotor(Actuator):
         saturation_effort: wp.array[float],
         velocity_limit: wp.array[float],
         constant_force: wp.array[float] | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -85,6 +87,7 @@ class ActuatorDCMotor(Actuator):
             saturation_effort: Peak motor torque at stall [N or N·m]. Shape ``(N,)``.
             velocity_limit: Maximum joint velocity for torque-speed curve [rad/s or m/s]. Shape ``(N,)``.
             constant_force: Constant offsets [N or N·m]. Shape ``(N,)``. ``None`` to skip.
+            state_pos_indices: Coordinate indices for position state.
             state_pos_attr: Attribute on :class:`~newton.State` for positions.
             state_vel_attr: Attribute on :class:`~newton.State` for velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -92,7 +95,14 @@ class ActuatorDCMotor(Actuator):
             control_input_attr: Attribute on :class:`~newton.Control` for control input. ``None`` to skip.
             control_output_attr: Attribute on :class:`~newton.Control` for output forces.
         """
-        super().__init__(input_indices, output_indices, control_output_attr)
+        if state_pos_indices is None:
+            raise ValueError("ActuatorDCMotor requires explicit state_pos_indices for direct construction")
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         for name, arr in [
             ("kp", kp),
@@ -145,6 +155,7 @@ class ActuatorDCMotor(Actuator):
                 getattr(sim_control, self.control_target_pos_attr),
                 getattr(sim_control, self.control_target_vel_attr),
                 control_input,
+                self.state_pos_indices,
                 self.input_indices,
                 self.input_indices,
                 output_indices,

--- a/newton/_src/actuators/actuators/delayed_pd.py
+++ b/newton/_src/actuators/actuators/delayed_pd.py
@@ -84,6 +84,8 @@ class ActuatorDelayedPD(Actuator):
         delay: int,
         max_force: wp.array[float],
         constant_force: wp.array[float] | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -101,6 +103,7 @@ class ActuatorDelayedPD(Actuator):
             delay: Number of timesteps to delay inputs.
             max_force: Force limits [N or N·m]. Shape ``(N,)``.
             constant_force: Constant offsets [N or N·m]. Shape ``(N,)``. ``None`` to skip.
+            state_pos_indices: Coordinate indices for position state.
             state_pos_attr: Attribute on :class:`~newton.State` for positions.
             state_vel_attr: Attribute on :class:`~newton.State` for velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -108,7 +111,14 @@ class ActuatorDelayedPD(Actuator):
             control_input_attr: Attribute on :class:`~newton.Control` for control input. ``None`` to skip.
             control_output_attr: Attribute on :class:`~newton.Control` for output forces.
         """
-        super().__init__(input_indices, output_indices, control_output_attr)
+        if state_pos_indices is None:
+            raise ValueError("ActuatorDelayedPD requires explicit state_pos_indices for direct construction")
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         for name, arr in [("kp", kp), ("kd", kd), ("max_force", max_force)]:
             if len(arr) != self.num_actuators:
@@ -161,6 +171,7 @@ class ActuatorDelayedPD(Actuator):
                 delayed_pos,
                 delayed_vel,
                 delayed_act,
+                self.state_pos_indices,
                 self.input_indices,
                 self._sequential_indices,
                 output_indices,

--- a/newton/_src/actuators/actuators/net_lstm.py
+++ b/newton/_src/actuators/actuators/net_lstm.py
@@ -90,6 +90,8 @@ class ActuatorNetLSTM(Actuator):
         max_force: wp.array[float],
         network: Any = None,
         network_path: str | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -104,6 +106,7 @@ class ActuatorNetLSTM(Actuator):
             network: Pre-trained LSTM network (``torch.nn.Module``). If ``None``, loaded
                 from *network_path*.
             network_path: Path to a TorchScript model file. Used when *network* is ``None``.
+            state_pos_indices: Coordinate indices for position state. Defaults to *input_indices*.
             state_pos_attr: Attribute on :class:`~newton.State` for joint positions.
             state_vel_attr: Attribute on :class:`~newton.State` for joint velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -111,7 +114,12 @@ class ActuatorNetLSTM(Actuator):
         """
         import torch
 
-        super().__init__(input_indices, output_indices, control_output_attr)
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         if len(max_force) != self.num_actuators:
             raise ValueError(f"max_force length ({len(max_force)}) must match num_actuators ({self.num_actuators})")
@@ -153,7 +161,10 @@ class ActuatorNetLSTM(Actuator):
         self._num_layers = lstm.num_layers
         self._hidden_size = lstm.hidden_size
 
-        self._torch_indices = torch.tensor(input_indices.numpy(), dtype=torch.long, device=self._torch_device)
+        self._torch_indices = torch.tensor(self.input_indices.numpy(), dtype=torch.long, device=self._torch_device)
+        self._torch_state_pos_indices = torch.tensor(
+            self.state_pos_indices.numpy(), dtype=torch.long, device=self._torch_device
+        )
 
         self._hidden: Any = None
         self._cell: Any = None
@@ -178,7 +189,7 @@ class ActuatorNetLSTM(Actuator):
         current_vel = wp.to_torch(getattr(sim_state, self.state_vel_attr))
         target_pos = wp.to_torch(getattr(sim_control, self.control_target_pos_attr))
 
-        pos_error = target_pos[self._torch_indices] - current_pos[self._torch_indices]
+        pos_error = target_pos[self._torch_indices] - current_pos[self._torch_state_pos_indices]
         vel = current_vel[self._torch_indices]
 
         # (num_actuators, 1, 2): seq_len=1, features=[pos_error, velocity]

--- a/newton/_src/actuators/actuators/net_mlp.py
+++ b/newton/_src/actuators/actuators/net_mlp.py
@@ -96,6 +96,8 @@ class ActuatorNetMLP(Actuator):
         input_idx: list[int] | None = None,
         network: Any = None,
         network_path: str | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -116,6 +118,7 @@ class ActuatorNetMLP(Actuator):
             network: Pre-trained network (``torch.nn.Module``). If ``None``, loaded from
                 *network_path*.
             network_path: Path to a TorchScript model file. Used when *network* is ``None``.
+            state_pos_indices: Coordinate indices for position state. Defaults to *input_indices*.
             state_pos_attr: Attribute on :class:`~newton.State` for joint positions.
             state_vel_attr: Attribute on :class:`~newton.State` for joint velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -123,7 +126,12 @@ class ActuatorNetMLP(Actuator):
         """
         import torch
 
-        super().__init__(input_indices, output_indices, control_output_attr)
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         if len(max_force) != self.num_actuators:
             raise ValueError(f"max_force length ({len(max_force)}) must match num_actuators ({self.num_actuators})")
@@ -153,7 +161,10 @@ class ActuatorNetMLP(Actuator):
         else:
             raise ValueError("Either 'network' or 'network_path' must be provided")
 
-        self._torch_indices = torch.tensor(input_indices.numpy(), dtype=torch.long, device=self._torch_device)
+        self._torch_indices = torch.tensor(self.input_indices.numpy(), dtype=torch.long, device=self._torch_device)
+        self._torch_state_pos_indices = torch.tensor(
+            self.state_pos_indices.numpy(), dtype=torch.long, device=self._torch_device
+        )
 
         self.state_pos_attr = state_pos_attr
         self.state_vel_attr = state_vel_attr
@@ -175,7 +186,7 @@ class ActuatorNetMLP(Actuator):
         current_vel = wp.to_torch(getattr(sim_state, self.state_vel_attr))
         target_pos = wp.to_torch(getattr(sim_control, self.control_target_pos_attr))
 
-        pos_error = target_pos[self._torch_indices] - current_pos[self._torch_indices]
+        pos_error = target_pos[self._torch_indices] - current_pos[self._torch_state_pos_indices]
         vel = current_vel[self._torch_indices]
 
         # Write current values at index 0; state manager will roll this into history.

--- a/newton/_src/actuators/actuators/pd.py
+++ b/newton/_src/actuators/actuators/pd.py
@@ -52,6 +52,8 @@ class ActuatorPD(Actuator):
         kd: wp.array[float],
         max_force: wp.array[float],
         constant_force: wp.array[float] | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -68,6 +70,7 @@ class ActuatorPD(Actuator):
             kd: Derivative gains. Shape ``(N,)``.
             max_force: Force limits [N or N·m]. Shape ``(N,)``.
             constant_force: Constant offsets [N or N·m]. Shape ``(N,)``. ``None`` to skip.
+            state_pos_indices: Coordinate indices for position state.
             state_pos_attr: Attribute on :class:`~newton.State` for positions.
             state_vel_attr: Attribute on :class:`~newton.State` for velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -75,7 +78,14 @@ class ActuatorPD(Actuator):
             control_input_attr: Attribute on :class:`~newton.Control` for control input. ``None`` to skip.
             control_output_attr: Attribute on :class:`~newton.Control` for output forces.
         """
-        super().__init__(input_indices, output_indices, control_output_attr)
+        if state_pos_indices is None:
+            raise ValueError("ActuatorPD requires explicit state_pos_indices for direct construction")
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         for name, arr in [("kp", kp), ("kd", kd), ("max_force", max_force)]:
             if len(arr) != self.num_actuators:
@@ -120,6 +130,7 @@ class ActuatorPD(Actuator):
                 getattr(sim_control, self.control_target_pos_attr),
                 getattr(sim_control, self.control_target_vel_attr),
                 control_input,
+                self.state_pos_indices,
                 self.input_indices,
                 self.input_indices,
                 output_indices,

--- a/newton/_src/actuators/actuators/pid.py
+++ b/newton/_src/actuators/actuators/pid.py
@@ -70,6 +70,8 @@ class ActuatorPID(Actuator):
         max_force: wp.array[float],
         integral_max: wp.array[float],
         constant_force: wp.array[float] | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -88,6 +90,7 @@ class ActuatorPID(Actuator):
             max_force: Force limits [N or N·m]. Shape ``(N,)``.
             integral_max: Anti-windup limits. Shape ``(N,)``.
             constant_force: Constant offsets [N or N·m]. Shape ``(N,)``. ``None`` to skip.
+            state_pos_indices: Coordinate indices for position state.
             state_pos_attr: Attribute on :class:`~newton.State` for positions.
             state_vel_attr: Attribute on :class:`~newton.State` for velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -95,7 +98,14 @@ class ActuatorPID(Actuator):
             control_input_attr: Attribute on :class:`~newton.Control` for control input. ``None`` to skip.
             control_output_attr: Attribute on :class:`~newton.Control` for output forces.
         """
-        super().__init__(input_indices, output_indices, control_output_attr)
+        if state_pos_indices is None:
+            raise ValueError("ActuatorPID requires explicit state_pos_indices for direct construction")
+        super().__init__(
+            input_indices,
+            output_indices,
+            state_pos_indices=state_pos_indices,
+            control_output_attr=control_output_attr,
+        )
 
         for name, arr in [
             ("kp", kp),
@@ -148,6 +158,7 @@ class ActuatorPID(Actuator):
                 getattr(sim_control, self.control_target_pos_attr),
                 getattr(sim_control, self.control_target_vel_attr),
                 control_input,
+                self.state_pos_indices,
                 self.input_indices,
                 self.input_indices,
                 output_indices,
@@ -178,7 +189,7 @@ class ActuatorPID(Actuator):
             inputs=[
                 getattr(sim_state, self.state_pos_attr),
                 getattr(sim_control, self.control_target_pos_attr),
-                self.input_indices,
+                self.state_pos_indices,
                 self.input_indices,
                 self.integral_max,
                 dt,

--- a/newton/_src/actuators/actuators/remotized_pd.py
+++ b/newton/_src/actuators/actuators/remotized_pd.py
@@ -71,6 +71,8 @@ class ActuatorRemotizedPD(ActuatorDelayedPD):
         lookup_angles: wp.array[float] | tuple[float, ...] | list[float],
         lookup_torques: wp.array[float] | tuple[float, ...] | list[float],
         constant_force: wp.array[float] | None = None,
+        *,
+        state_pos_indices: wp.array[wp.uint32] | None = None,
         state_pos_attr: str = "joint_q",
         state_vel_attr: str = "joint_qd",
         control_target_pos_attr: str = "joint_target_pos",
@@ -92,6 +94,7 @@ class ActuatorRemotizedPD(ActuatorDelayedPD):
             lookup_torques: Max output torques [N·m] corresponding to *lookup_angles*.
                 Shape ``(K,)``. Accepts ``wp.array``, ``tuple``, or ``list``.
             constant_force: Constant offsets [N or N·m]. Shape ``(N,)``. ``None`` to skip.
+            state_pos_indices: Coordinate indices for position state.
             state_pos_attr: Attribute on :class:`~newton.State` for positions.
             state_vel_attr: Attribute on :class:`~newton.State` for velocities.
             control_target_pos_attr: Attribute on :class:`~newton.Control` for target positions.
@@ -111,6 +114,7 @@ class ActuatorRemotizedPD(ActuatorDelayedPD):
             delay=delay,
             max_force=max_force_dummy,
             constant_force=constant_force,
+            state_pos_indices=state_pos_indices,
             state_pos_attr=state_pos_attr,
             state_vel_attr=state_vel_attr,
             control_target_pos_attr=control_target_pos_attr,
@@ -164,6 +168,7 @@ class ActuatorRemotizedPD(ActuatorDelayedPD):
                 delayed_pos,
                 delayed_vel,
                 delayed_act,
+                self.state_pos_indices,
                 self.input_indices,
                 self._sequential_indices,
                 output_indices,

--- a/newton/_src/actuators/kernels.py
+++ b/newton/_src/actuators/kernels.py
@@ -35,7 +35,8 @@ def pd_controller_kernel(
     target_pos: wp.array[float],
     target_vel: wp.array[float],
     control_input: wp.array[float],
-    state_indices: wp.array[wp.uint32],
+    state_pos_indices: wp.array[wp.uint32],
+    state_vel_indices: wp.array[wp.uint32],
     target_indices: wp.array[wp.uint32],
     output_indices: wp.array[wp.uint32],
     kp: wp.array[float],
@@ -63,12 +64,13 @@ def pd_controller_kernel(
     Result is added to output.
     """
     i = wp.tid()
-    state_idx = state_indices[i]
+    state_pos_idx = state_pos_indices[i]
+    state_vel_idx = state_vel_indices[i]
     target_idx = target_indices[i]
     out_idx = output_indices[i]
 
-    position_error = target_pos[target_idx] - current_pos[state_idx]
-    velocity_error = target_vel[target_idx] - current_vel[state_idx]
+    position_error = target_pos[target_idx] - current_pos[state_pos_idx]
+    velocity_error = target_vel[target_idx] - current_vel[state_vel_idx]
 
     const_f = float(0.0)
     if constant_force:
@@ -81,7 +83,7 @@ def pd_controller_kernel(
     force = const_f + act + kp[i] * position_error + kd[i] * velocity_error
 
     if saturation_effort:
-        vel = current_vel[state_idx]
+        vel = current_vel[state_vel_idx]
         sat = saturation_effort[i]
         vel_lim = velocity_limit[i]
         max_f = max_force[i]
@@ -89,7 +91,7 @@ def pd_controller_kernel(
         min_torque = wp.clamp(sat * (-1.0 - vel / vel_lim), -max_f, 0.0)
         force = wp.clamp(force, min_torque, max_torque)
     elif lookup_size > 0:
-        torque_limit = _interp_1d(current_pos[state_idx], lookup_angles, lookup_torques, lookup_size)
+        torque_limit = _interp_1d(current_pos[state_pos_idx], lookup_angles, lookup_torques, lookup_size)
         force = wp.clamp(force, -torque_limit, torque_limit)
     else:
         force = wp.clamp(force, -max_force[i], max_force[i])
@@ -118,7 +120,8 @@ def pid_controller_kernel(
     target_pos: wp.array[float],
     target_vel: wp.array[float],
     control_input: wp.array[float],
-    state_indices: wp.array[wp.uint32],
+    state_pos_indices: wp.array[wp.uint32],
+    state_vel_indices: wp.array[wp.uint32],
     target_indices: wp.array[wp.uint32],
     output_indices: wp.array[wp.uint32],
     kp: wp.array[float],
@@ -133,12 +136,13 @@ def pid_controller_kernel(
 ):
     """PID control with anti-windup: f = clamp(constant + act + kp*(target_pos - q) + ki*integral + kd*(target_vel - v), ±max_force). Adds to output."""
     i = wp.tid()
-    state_idx = state_indices[i]
+    state_pos_idx = state_pos_indices[i]
+    state_vel_idx = state_vel_indices[i]
     target_idx = target_indices[i]
     out_idx = output_indices[i]
 
-    position_error = target_pos[target_idx] - current_pos[state_idx]
-    velocity_error = target_vel[target_idx] - current_vel[state_idx]
+    position_error = target_pos[target_idx] - current_pos[state_pos_idx]
+    velocity_error = target_vel[target_idx] - current_vel[state_vel_idx]
 
     integral = current_integral[i] + position_error * dt
     integral = wp.clamp(integral, -integral_max[i], integral_max[i])
@@ -161,7 +165,7 @@ def pid_controller_kernel(
 def pid_integral_state_kernel(
     current_pos: wp.array[float],
     target_pos: wp.array[float],
-    state_indices: wp.array[wp.uint32],
+    state_pos_indices: wp.array[wp.uint32],
     target_indices: wp.array[wp.uint32],
     integral_max: wp.array[float],
     dt: float,
@@ -170,10 +174,10 @@ def pid_integral_state_kernel(
 ):
     """Update PID integral state with anti-windup."""
     i = wp.tid()
-    state_idx = state_indices[i]
+    state_pos_idx = state_pos_indices[i]
     target_idx = target_indices[i]
 
-    position_error = target_pos[target_idx] - current_pos[state_idx]
+    position_error = target_pos[target_idx] - current_pos[state_pos_idx]
 
     integral = current_integral[i] + position_error * dt
     integral = wp.clamp(integral, -integral_max[i], integral_max[i])

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -195,12 +195,13 @@ class ModelBuilder:
     class ActuatorEntry:
         """Stores accumulated indices and arguments for one actuator type + scalar params combo.
 
-        Each element in input_indices/output_indices represents one actuator.
+        Each element in input_indices/state_pos_indices/output_indices represents one actuator.
         For single-input actuators: [[idx1], [idx2], ...] → flattened to 1D array
         For multi-input actuators: [[idx1, idx2], [idx3, idx4], ...] → 2D array
         """
 
         input_indices: list[list[int]]  # Per-actuator input indices
+        state_pos_indices: list[list[int]]  # Per-actuator position-state indices
         output_indices: list[list[int]]  # Per-actuator output indices
         args: list[dict[str, Any]]  # Per-actuator array params (scalar params in dict key)
 
@@ -1679,6 +1680,7 @@ class ModelBuilder:
         actuator_class: type[Actuator],
         input_indices: list[int],
         output_indices: list[int] | None = None,
+        state_pos_indices: list[int] | None = None,
         **kwargs: Any,
     ) -> None:
         """Add an external actuator, independent of any ``UsdPhysics`` joint drives.
@@ -1694,12 +1696,15 @@ class ModelBuilder:
             input_indices: DOF indices this actuator reads from. Length 1 for single-input,
                 length > 1 for multi-input actuators.
             output_indices: DOF indices for writing output. Defaults to *input_indices*.
+            state_pos_indices: Coordinate indices for reading position state. Defaults
+                to the inferred mapping for *input_indices*.
             **kwargs: Actuator parameters (e.g., ``kp``, ``kd``, ``max_force``).
         """
+        resolved = actuator_class.resolve_arguments(kwargs)
+        if state_pos_indices is None:
+            state_pos_indices = self._infer_state_pos_indices(input_indices)
         if output_indices is None:
             output_indices = input_indices.copy()
-
-        resolved = actuator_class.resolve_arguments(kwargs)
 
         # Extract scalar params to form the entry key
         scalar_param_names = getattr(actuator_class, "SCALAR_PARAMS", set())
@@ -1709,7 +1714,7 @@ class ModelBuilder:
         entry_key = (actuator_class, scalar_key)
         entry = self.actuator_entries.setdefault(
             entry_key,
-            ModelBuilder.ActuatorEntry(input_indices=[], output_indices=[], args=[]),
+            ModelBuilder.ActuatorEntry(input_indices=[], state_pos_indices=[], output_indices=[], args=[]),
         )
 
         # Filter out scalar params from args (they're already in the key)
@@ -1724,6 +1729,14 @@ class ModelBuilder:
                     f"expected {expected_input_dim}, got {len(input_indices)}. "
                     f"All actuators of the same type must have the same number of inputs."
                 )
+        if entry.state_pos_indices:
+            expected_state_pos_dim = len(entry.state_pos_indices[0])
+            if len(state_pos_indices) != expected_state_pos_dim:
+                raise ValueError(
+                    f"State position indices dimension mismatch for {actuator_class.__name__}: "
+                    f"expected {expected_state_pos_dim}, got {len(state_pos_indices)}. "
+                    f"All actuators of the same type must have the same number of position-state inputs."
+                )
         if entry.output_indices:
             expected_output_dim = len(entry.output_indices[0])
             if len(output_indices) != expected_output_dim:
@@ -1735,8 +1748,43 @@ class ModelBuilder:
 
         # Each call adds one actuator with its input/output indices
         entry.input_indices.append(input_indices)
+        entry.state_pos_indices.append(state_pos_indices)
         entry.output_indices.append(output_indices)
         entry.args.append(array_params)
+
+    def _infer_state_pos_indices(self, input_indices: list[int]) -> list[int]:
+        """Map actuator DOF indices to position-coordinate indices."""
+        joint_q_start = [*self.joint_q_start, self.joint_coord_count]
+        joint_qd_start = [*self.joint_qd_start, self.joint_dof_count]
+
+        dof_to_joint = np.full(self.joint_dof_count, -1, dtype=np.int32)
+        for joint_index, dof_start in enumerate(self.joint_qd_start):
+            dof_to_joint[dof_start:joint_qd_start[joint_index + 1]] = joint_index
+
+        state_pos_indices: list[int] = []
+        for dof_index in input_indices:
+            if dof_index < 0 or dof_index >= self.joint_dof_count:
+                raise ValueError(f"Actuator input index {dof_index} is out of range for joint_dof_count={self.joint_dof_count}")
+
+            joint_index = int(dof_to_joint[dof_index])
+            if joint_index < 0:
+                raise ValueError(f"Could not resolve joint for actuator input index {dof_index}")
+
+            q_start = joint_q_start[joint_index]
+            qd_start = joint_qd_start[joint_index]
+            coord_count = joint_q_start[joint_index + 1] - q_start
+            dof_count = joint_qd_start[joint_index + 1] - qd_start
+            if coord_count != dof_count:
+                joint_label = self.joint_label[joint_index]
+                raise ValueError(
+                    f"Cannot infer state_pos_indices for joint {joint_index} ('{joint_label}') from DOF index {dof_index}: "
+                    f"joint_coord_count={coord_count}, joint_dof_count={dof_count}. "
+                    f"Pass state_pos_indices=... explicitly."
+                )
+
+            state_pos_indices.append(q_start + (dof_index - qd_start))
+
+        return state_pos_indices
 
     def _stack_args_to_arrays(
         self,
@@ -3266,11 +3314,13 @@ class ModelBuilder:
         for entry_key, sub_entry in builder.actuator_entries.items():
             entry = self.actuator_entries.setdefault(
                 entry_key,
-                ModelBuilder.ActuatorEntry(input_indices=[], output_indices=[], args=[]),
+                ModelBuilder.ActuatorEntry(input_indices=[], state_pos_indices=[], output_indices=[], args=[]),
             )
             # Offset indices by start_joint_dof_idx (each actuator's indices are a list)
             for idx_list in sub_entry.input_indices:
                 entry.input_indices.append([idx + start_joint_dof_idx for idx in idx_list])
+            for idx_list in sub_entry.state_pos_indices:
+                entry.state_pos_indices.append([idx + start_joint_coord_idx for idx in idx_list])
             for idx_list in sub_entry.output_indices:
                 entry.output_indices.append([idx + start_joint_dof_idx for idx in idx_list])
             entry.args.extend(sub_entry.args)
@@ -10300,12 +10350,14 @@ class ModelBuilder:
             m.actuators = []
             for (actuator_class, scalar_key), entry in self.actuator_entries.items():
                 input_indices = self._build_index_array(entry.input_indices, device)
+                state_pos_indices = self._build_index_array(entry.state_pos_indices, device)
                 output_indices = self._build_index_array(entry.output_indices, device)
                 param_arrays = self._stack_args_to_arrays(entry.args, device=device, requires_grad=requires_grad)
                 scalar_params = dict(scalar_key)
                 actuator = actuator_class(
                     input_indices=input_indices,
                     output_indices=output_indices,
+                    state_pos_indices=state_pos_indices,
                     **param_arrays,
                     **scalar_params,
                 )

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1759,12 +1759,14 @@ class ModelBuilder:
 
         dof_to_joint = np.full(self.joint_dof_count, -1, dtype=np.int32)
         for joint_index, dof_start in enumerate(self.joint_qd_start):
-            dof_to_joint[dof_start:joint_qd_start[joint_index + 1]] = joint_index
+            dof_to_joint[dof_start : joint_qd_start[joint_index + 1]] = joint_index
 
         state_pos_indices: list[int] = []
         for dof_index in input_indices:
             if dof_index < 0 or dof_index >= self.joint_dof_count:
-                raise ValueError(f"Actuator input index {dof_index} is out of range for joint_dof_count={self.joint_dof_count}")
+                raise ValueError(
+                    f"Actuator input index {dof_index} is out of range for joint_dof_count={self.joint_dof_count}"
+                )
 
             joint_index = int(dof_to_joint[dof_index])
             if joint_index < 0:
@@ -10354,13 +10356,23 @@ class ModelBuilder:
                 output_indices = self._build_index_array(entry.output_indices, device)
                 param_arrays = self._stack_args_to_arrays(entry.args, device=device, requires_grad=requires_grad)
                 scalar_params = dict(scalar_key)
-                actuator = actuator_class(
-                    input_indices=input_indices,
-                    output_indices=output_indices,
-                    state_pos_indices=state_pos_indices,
-                    **param_arrays,
-                    **scalar_params,
-                )
+                try:
+                    actuator = actuator_class(
+                        input_indices=input_indices,
+                        output_indices=output_indices,
+                        state_pos_indices=state_pos_indices,
+                        **param_arrays,
+                        **scalar_params,
+                    )
+                except TypeError as exc:
+                    if "state_pos_indices" not in str(exc):
+                        raise
+                    raise TypeError(
+                        f"{actuator_class.__name__} does not accept state_pos_indices. "
+                        "This usually means ModelBuilder is paired with a legacy actuator class. "
+                        "Switch to newton.actuators or update the actuator class to accept "
+                        "state_pos_indices."
+                    ) from exc
                 m.actuators.append(actuator)
 
             # Add custom attributes onto the model (with lazy evaluation)

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -59,6 +59,7 @@ class TestActuatorPDUnit(unittest.TestCase):
         actuator = ActuatorPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0, 100.0], dtype=wp.float32),
             kd=wp.array([10.0, 10.0, 10.0], dtype=wp.float32),
             max_force=wp.array([50.0, 50.0, 50.0], dtype=wp.float32),
@@ -76,6 +77,7 @@ class TestActuatorPDUnit(unittest.TestCase):
         actuator = ActuatorPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0, 100.0], dtype=wp.float32),
             kd=wp.array([0.0, 0.0, 0.0], dtype=wp.float32),
             max_force=wp.array([1000.0, 1000.0, 1000.0], dtype=wp.float32),
@@ -95,6 +97,45 @@ class TestActuatorPDUnit(unittest.TestCase):
         actuator.step(sim_state, sim_control, None, None)
         forces = sim_control.joint_f.numpy()
         np.testing.assert_allclose(forces, [100.0, 200.0, 300.0], rtol=1e-5)
+
+    def test_pd_requires_state_pos_indices(self):
+        """Test that direct PD construction fails without position indices."""
+        indices = wp.array([0], dtype=wp.uint32)
+        with self.assertRaisesRegex(ValueError, "state_pos_indices"):
+            ActuatorPD(
+                input_indices=indices,
+                output_indices=indices,
+                kp=wp.array([100.0], dtype=wp.float32),
+                kd=wp.array([0.0], dtype=wp.float32),
+                max_force=wp.array([1000.0], dtype=wp.float32),
+            )
+
+    def test_pd_actuator_shifted_position_indices(self):
+        """Test that PD can read q from a shifted coordinate index."""
+        input_indices = wp.array([6], dtype=wp.uint32)
+        state_pos_indices = wp.array([7], dtype=wp.uint32)
+        actuator = ActuatorPD(
+            input_indices=input_indices,
+            output_indices=input_indices,
+            state_pos_indices=state_pos_indices,
+            kp=wp.array([10.0], dtype=wp.float32),
+            kd=wp.array([0.0], dtype=wp.float32),
+            max_force=wp.array([1000.0], dtype=wp.float32),
+        )
+
+        sim_state = MockSimState(
+            joint_q=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.25], dtype=wp.float32),
+            joint_qd=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+        )
+        sim_control = MockSimControl(
+            joint_target_pos=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.25], dtype=wp.float32),
+            joint_target_vel=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_act=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_f=wp.zeros(7, dtype=wp.float32),
+        )
+
+        actuator.step(sim_state, sim_control, None, None)
+        self.assertAlmostEqual(sim_control.joint_f.numpy()[6], 10.0, places=5)
 
     def test_pd_actuator_resolve_arguments(self):
         """Test that resolve_arguments fills defaults correctly."""
@@ -116,6 +157,7 @@ class TestActuatorDelayedPDUnit(unittest.TestCase):
         actuator = ActuatorDelayedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             kd=wp.array([10.0, 10.0], dtype=wp.float32),
             delay=5,
@@ -134,6 +176,7 @@ class TestActuatorDelayedPDUnit(unittest.TestCase):
         actuator = ActuatorDelayedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             kd=wp.array([10.0, 10.0], dtype=wp.float32),
             delay=delay,
@@ -162,6 +205,7 @@ class TestActuatorDelayedPDUnit(unittest.TestCase):
         actuator = ActuatorDelayedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             delay=delay,
@@ -217,6 +261,7 @@ class TestActuatorPIDUnit(unittest.TestCase):
         actuator = ActuatorPID(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             ki=wp.array([10.0, 10.0], dtype=wp.float32),
             kd=wp.array([5.0, 5.0], dtype=wp.float32),
@@ -235,6 +280,7 @@ class TestActuatorPIDUnit(unittest.TestCase):
         actuator = ActuatorPID(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             ki=wp.array([10.0, 10.0], dtype=wp.float32),
             kd=wp.array([5.0, 5.0], dtype=wp.float32),
@@ -246,6 +292,51 @@ class TestActuatorPIDUnit(unittest.TestCase):
         self.assertIsInstance(state, ActuatorPID.State)
         self.assertEqual(state.integral.shape[0], num_dofs)
         np.testing.assert_array_equal(state.integral.numpy(), [0.0, 0.0])
+
+    def test_pid_requires_state_pos_indices(self):
+        """Test that direct PID construction fails without position indices."""
+        indices = wp.array([0], dtype=wp.uint32)
+        with self.assertRaisesRegex(ValueError, "state_pos_indices"):
+            ActuatorPID(
+                input_indices=indices,
+                output_indices=indices,
+                kp=wp.array([100.0], dtype=wp.float32),
+                ki=wp.array([10.0], dtype=wp.float32),
+                kd=wp.array([0.0], dtype=wp.float32),
+                max_force=wp.array([1000.0], dtype=wp.float32),
+                integral_max=wp.array([100.0], dtype=wp.float32),
+            )
+
+    def test_pid_actuator_shifted_position_indices(self):
+        """Test that PID can read q from a shifted coordinate index."""
+        input_indices = wp.array([6], dtype=wp.uint32)
+        state_pos_indices = wp.array([7], dtype=wp.uint32)
+        actuator = ActuatorPID(
+            input_indices=input_indices,
+            output_indices=input_indices,
+            state_pos_indices=state_pos_indices,
+            kp=wp.array([10.0], dtype=wp.float32),
+            ki=wp.array([0.0], dtype=wp.float32),
+            kd=wp.array([0.0], dtype=wp.float32),
+            max_force=wp.array([1000.0], dtype=wp.float32),
+            integral_max=wp.array([100.0], dtype=wp.float32),
+        )
+
+        state_a = actuator.state()
+        state_b = actuator.state()
+        sim_state = MockSimState(
+            joint_q=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.25], dtype=wp.float32),
+            joint_qd=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+        )
+        sim_control = MockSimControl(
+            joint_target_pos=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.25], dtype=wp.float32),
+            joint_target_vel=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_act=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_f=wp.zeros(7, dtype=wp.float32),
+        )
+
+        actuator.step(sim_state, sim_control, state_a, state_b, dt=0.01)
+        self.assertAlmostEqual(sim_control.joint_f.numpy()[6], 10.0, places=5)
 
 
 class TestActuatorDCMotorUnit(unittest.TestCase):
@@ -260,6 +351,7 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         actuator = ActuatorDCMotor(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             kd=wp.array([10.0, 10.0], dtype=wp.float32),
             max_force=wp.array([50.0, 50.0], dtype=wp.float32),
@@ -289,6 +381,7 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         actuator = ActuatorDCMotor(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             max_force=wp.array([200.0], dtype=wp.float32),
@@ -317,6 +410,7 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         actuator = ActuatorDCMotor(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1000.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             max_force=wp.array([200.0], dtype=wp.float32),
@@ -345,6 +439,7 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         actuator = ActuatorDCMotor(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1000.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             max_force=wp.array([200.0], dtype=wp.float32),
@@ -373,6 +468,7 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         actuator = ActuatorDCMotor(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1000.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             max_force=wp.array([200.0], dtype=wp.float32),
@@ -395,6 +491,35 @@ class TestActuatorDCMotorUnit(unittest.TestCase):
         force = sim_control.joint_f.numpy()[0]
         self.assertAlmostEqual(force, 150.0, places=3)
 
+    def test_dc_motor_shifted_position_indices(self):
+        """Test that DC motor uses shifted position indices for PD error."""
+        input_indices = wp.array([6], dtype=wp.uint32)
+        state_pos_indices = wp.array([7], dtype=wp.uint32)
+        actuator = ActuatorDCMotor(
+            input_indices=input_indices,
+            output_indices=input_indices,
+            state_pos_indices=state_pos_indices,
+            kp=wp.array([10.0], dtype=wp.float32),
+            kd=wp.array([0.0], dtype=wp.float32),
+            max_force=wp.array([1000.0], dtype=wp.float32),
+            saturation_effort=wp.array([1000.0], dtype=wp.float32),
+            velocity_limit=wp.array([10.0], dtype=wp.float32),
+        )
+
+        sim_state = MockSimState(
+            joint_q=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.25], dtype=wp.float32),
+            joint_qd=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+        )
+        sim_control = MockSimControl(
+            joint_target_pos=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.25], dtype=wp.float32),
+            joint_target_vel=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_act=wp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=wp.float32),
+            joint_f=wp.zeros(7, dtype=wp.float32),
+        )
+
+        actuator.step(sim_state, sim_control, None, None)
+        self.assertAlmostEqual(sim_control.joint_f.numpy()[6], 10.0, places=5)
+
 
 class TestActuatorRemotizedPDUnit(unittest.TestCase):
     """Tests for ActuatorRemotizedPD."""
@@ -416,6 +541,7 @@ class TestActuatorRemotizedPDUnit(unittest.TestCase):
         actuator = ActuatorRemotizedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0, 100.0], dtype=wp.float32),
             kd=wp.array([10.0, 10.0], dtype=wp.float32),
             delay=3,
@@ -443,6 +569,7 @@ class TestActuatorRemotizedPDUnit(unittest.TestCase):
         actuator = ActuatorRemotizedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1000.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             delay=delay,
@@ -482,6 +609,7 @@ class TestActuatorRemotizedPDUnit(unittest.TestCase):
         actuator = ActuatorRemotizedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([1000.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             delay=delay,
@@ -524,6 +652,7 @@ class TestActuatorRemotizedPDUnit(unittest.TestCase):
         actuator = ActuatorRemotizedPD(
             input_indices=indices,
             output_indices=indices,
+            state_pos_indices=indices,
             kp=wp.array([100.0], dtype=wp.float32),
             kd=wp.array([0.0], dtype=wp.float32),
             delay=delay,

--- a/newton/tests/test_actuators_integration.py
+++ b/newton/tests/test_actuators_integration.py
@@ -280,6 +280,32 @@ class TestActuatorBuilder(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "state_pos_indices"):
             builder.add_actuator(ActuatorPD, input_indices=[dof], kp=100.0)
 
+    def test_builder_raises_clear_error_for_legacy_actuator_classes(self):
+        """Test that builder surfaces a migration error for actuator classes without state_pos_indices."""
+
+        class LegacyActuator:
+            SCALAR_PARAMS = frozenset()
+
+            @staticmethod
+            def resolve_arguments(kwargs):
+                return kwargs
+
+            def __init__(self, input_indices, output_indices, kp):
+                self.input_indices = input_indices
+                self.output_indices = output_indices
+                self.kp = kp
+
+        builder = newton.ModelBuilder()
+        body = builder.add_body()
+        joint = builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z)
+        builder.add_articulation([joint])
+
+        dof = builder.joint_qd_start[joint]
+        builder.add_actuator(LegacyActuator, input_indices=[dof], kp=100.0)
+
+        with self.assertRaisesRegex(TypeError, "does not accept state_pos_indices"):
+            builder.finalize()
+
 
 @unittest.skipUnless(HAS_USD, "pxr not installed")
 class TestActuatorUSDParsing(unittest.TestCase):

--- a/newton/tests/test_actuators_integration.py
+++ b/newton/tests/test_actuators_integration.py
@@ -51,6 +51,10 @@ class TestActuatorBuilder(unittest.TestCase):
         self.assertEqual(act.num_actuators, 3)
 
         np.testing.assert_array_equal(act.input_indices.numpy(), [dofs[0], dofs[1], dofs[1]])
+        np.testing.assert_array_equal(
+            act.state_pos_indices.numpy(),
+            [builder.joint_q_start[joints[0]], builder.joint_q_start[joints[1]], builder.joint_q_start[joints[1]]],
+        )
         np.testing.assert_array_equal(act.output_indices.numpy(), [dofs[0], dofs[1], dofs[2]])
         np.testing.assert_array_almost_equal(act.kp.numpy(), [50.0, 100.0, 150.0])
         np.testing.assert_array_almost_equal(act.kd.numpy(), [0.0, 10.0, 0.0])
@@ -208,6 +212,73 @@ class TestActuatorBuilder(unittest.TestCase):
             builder.add_actuator(ActuatorPD, input_indices=[dofs[1], dofs[2]], kp=200.0)
 
         self.assertIn("dimension mismatch", str(ctx.exception))
+
+    def test_revolute_builder_uses_joint_q_start_for_state_pos_indices(self):
+        """Test that builder stores q-space indices for single-DOF revolute joints."""
+        builder = newton.ModelBuilder()
+        body = builder.add_body()
+        joint = builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z)
+        builder.add_articulation([joint])
+
+        dof = builder.joint_qd_start[joint]
+        q_index = builder.joint_q_start[joint]
+        self.assertNotEqual(dof, q_index)
+        builder.add_actuator(ActuatorPD, input_indices=[dof], kp=100.0)
+
+        model = builder.finalize()
+        actuator = model.actuators[0]
+
+        np.testing.assert_array_equal(actuator.input_indices.numpy(), [dof])
+        np.testing.assert_array_equal(actuator.state_pos_indices.numpy(), [q_index])
+
+    def test_floating_base_builder_infers_shifted_state_pos_indices(self):
+        """Test that builder infers q-space indices for downstream joints under a floating root."""
+        builder = newton.ModelBuilder()
+        root = builder.add_body()
+        link = builder.add_body()
+        joint_root = builder.add_joint_free(parent=-1, child=root)
+        joint_hinge = builder.add_joint_revolute(parent=root, child=link, axis=newton.Axis.Z)
+        builder.add_articulation([joint_root, joint_hinge])
+
+        dof = builder.joint_qd_start[joint_hinge]
+        q_index = builder.joint_q_start[joint_hinge]
+        self.assertNotEqual(dof, q_index)
+
+        builder.add_actuator(ActuatorPD, input_indices=[dof], kp=100.0)
+        model = builder.finalize()
+        actuator = model.actuators[0]
+
+        np.testing.assert_array_equal(actuator.input_indices.numpy(), [dof])
+        np.testing.assert_array_equal(actuator.state_pos_indices.numpy(), [q_index])
+
+    def test_builder_preserves_explicit_state_pos_indices(self):
+        """Test that explicit state_pos_indices override builder inference."""
+        builder = newton.ModelBuilder()
+        root = builder.add_body()
+        link = builder.add_body()
+        joint_root = builder.add_joint_free(parent=-1, child=root)
+        joint_hinge = builder.add_joint_revolute(parent=root, child=link, axis=newton.Axis.Z)
+        builder.add_articulation([joint_root, joint_hinge])
+
+        dof = builder.joint_qd_start[joint_hinge]
+        override = builder.joint_q_start[joint_root]
+
+        builder.add_actuator(ActuatorPD, input_indices=[dof], state_pos_indices=[override], kp=100.0)
+        model = builder.finalize()
+        actuator = model.actuators[0]
+
+        np.testing.assert_array_equal(actuator.state_pos_indices.numpy(), [override])
+
+    def test_builder_requires_explicit_state_pos_indices_for_free_joint(self):
+        """Test that builder rejects ambiguous free-joint inference."""
+        builder = newton.ModelBuilder()
+        body = builder.add_body()
+        joint = builder.add_joint_free(parent=-1, child=body)
+        builder.add_articulation([joint])
+
+        dof = builder.joint_qd_start[joint]
+        with self.assertRaisesRegex(ValueError, "state_pos_indices"):
+            builder.add_actuator(ActuatorPD, input_indices=[dof], kp=100.0)
 
 
 @unittest.skipUnless(HAS_USD, "pxr not installed")


### PR DESCRIPTION
I had a patch for newton actuator internally but i just saw your draft pr so i cleaned it up. 

This adds `state_pos_indices` to the external actuator API so position reads can use q-space indices independently from DOF-space `input_indices` and `output_indices`.

changes:
- threads `state_pos_indices` through the PD-family actuator stack and kernels
- teaches `ModelBuilder.add_actuator(...)` to infer q-space indices when the joint-local mapping is 1:1
- fails loudly on ambiguous joints unless `state_pos_indices` is provided explicitly
- adds standalone unit/integration coverage for shifted q/qd layouts

this is  needed because:
- floating-base robots can have downstream joints where `joint_q_start != joint_qd_start`
- in our downstream use this shows up on an excavator robot with a floating base, where actuator position feedback was reading the wrong slot from `joint_q`
