### PR TITLE
Fix deterministic solver scoping

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -571,6 +571,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         warp_util._KERNEL_CACHE.clear()
         SolverMuJoCo._generated_kernel_deterministic_options = options
 
+    def _set_mujoco_warp_module_options(self) -> None:
+        """Configure loaded shared modules without overriding code-generated bounds."""
+        options = {
+            "deterministic": self._deterministic,
+            "deterministic_max_records": 0,
+        }
+        for module in [*_mujoco_warp_deterministic_modules(), kernels]:
+            self._set_module_options(options, module=module)
+
     @staticmethod
     def _parse_integrator(value: str | int, context: dict[str, Any] | None = None) -> int:
         """Parse integrator option: Euler=0, RK4=1, implicit=2, implicitfast=3."""
@@ -3343,12 +3352,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             # path and compacts contacts with atomics. Keep the resolved mode
             # as the single source of truth instead of relying on global Warp
             # determinism during module import.
-            options = {
-                "deterministic": self._deterministic,
-                "deterministic_max_records": self._deterministic_max_records,
-            }
-            for module in [*_mujoco_warp_deterministic_modules(), kernels]:
-                self._set_module_options(options, module=module)
+            self._set_mujoco_warp_module_options()
 
         # Deferred from module scope: wp.static() in this kernel imports mujoco_warp.
         if SolverMuJoCo._convert_mjw_contacts_to_newton_kernel is None:
@@ -3604,6 +3608,14 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             wp.config.deterministic = original_mode
             wp.config.deterministic_max_records = original_max_records
 
+    @contextmanager
+    def _scoped_mujoco_warp_execution(self):
+        """Prepare and apply all solver-local MJWarp compilation options."""
+        self._apply_module_options()
+        self._prepare_generated_kernels()
+        with self._scoped_deterministic_config():
+            yield
+
     @event_scope
     def _mujoco_warp_step(self):
         self._mujoco_warp.step(self.mjw_model, self.mjw_data)
@@ -3611,9 +3623,6 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
     @event_scope
     @override
     def step(self, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float) -> None:
-        self._apply_module_options()
-        if not self.use_mujoco_cpu:
-            self._prepare_generated_kernels()
         if self.use_mujoco_cpu:
             self._apply_mjc_control(self.model, state_in, control, self.mj_data)
             if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
@@ -3623,17 +3632,16 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             self._mujoco.mj_step(self.mj_model, self.mj_data)
             self._update_newton_state(self.model, state_out, self.mj_data, state_prev=state_in)
         else:
-            self._enable_rne_postconstraint(state_out)
-            self._apply_mjc_control(self.model, state_in, control, self.mjw_data)
-            if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
-                self._update_mjc_data(self.mjw_data, self.model, state_in)
-            self.mjw_model.opt.timestep.fill_(dt)
-            with wp.ScopedDevice(self.model.device), self._scoped_deterministic_config():
+            with wp.ScopedDevice(self.model.device), self._scoped_mujoco_warp_execution():
+                self._enable_rne_postconstraint(state_out)
+                self._apply_mjc_control(self.model, state_in, control, self.mjw_data)
+                if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
+                    self._update_mjc_data(self.mjw_data, self.model, state_in)
+                self.mjw_model.opt.timestep.fill_(dt)
                 if not self.mjw_model.opt.run_collision_detection:
                     self._convert_contacts_to_mjwarp(self.model, state_in, contacts)
                 self._mujoco_warp_step()
-
-            self._update_newton_state(self.model, state_out, self.mjw_data, state_prev=state_in)
+                self._update_newton_state(self.model, state_out, self.mjw_data, state_prev=state_in)
         self._step += 1
 
     @override
@@ -4061,7 +4069,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
     @override
     def notify_model_changed(self, flags: ModelFlags | int) -> None:
-        self._apply_module_options()
+        if self.use_mujoco_cpu:
+            self._notify_model_changed(flags)
+        else:
+            with self._scoped_mujoco_warp_execution():
+                self._notify_model_changed(flags)
+
+    def _notify_model_changed(self, flags: ModelFlags | int) -> None:
         need_const_fixed = False
         need_const_0 = False
         need_length_range = False
@@ -6793,12 +6807,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     self._deterministic_max_records = _mujoco_warp_deterministic_max_records(
                         self.mj_model, self.mjw_data
                     )
-                options = {
-                    "deterministic": self._deterministic,
-                    "deterministic_max_records": self._deterministic_max_records,
-                }
-                for module in [*_mujoco_warp_deterministic_modules(), kernels]:
-                    self._set_module_options(options, module=module)
+                self._set_mujoco_warp_module_options()
                 self._prepare_generated_kernels()
 
             # expand model fields that can be expanded:

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -27,7 +27,7 @@ from ..coupled.interface import CouplingInterface
 from ..solver import SolverBase
 from ..xpbd import kernels as xpbd_kernels
 from ..xpbd.kernels import apply_joint_forces
-from . import particle_vbd_kernels, rigid_vbd_kernels
+from . import particle_vbd_kernels, rigid_vbd_kernels, vbd_coupling_kernels
 from .particle_vbd_kernels import (
     NUM_THREADS_PER_COLLISION_PRIMITIVE,
     TILE_SIZE_TRI_MESH_ELASTICITY_SOLVE,
@@ -379,6 +379,7 @@ class SolverVBD(SolverBase, CouplingInterface):
 
         effective_deterministic = deterministic if deterministic is not None else wp.config.deterministic
         particle_deterministic_max_records = 0
+        coupling_deterministic_max_records = 0
         if particle_enable_self_contact and effective_deterministic != wp.DeterministicMode.NOT_GUARANTEED:
             edge_iterations = (
                 particle_edge_contact_buffer_size + NUM_THREADS_PER_COLLISION_PRIMITIVE - 1
@@ -391,6 +392,7 @@ class SolverVBD(SolverBase, CouplingInterface):
             if model.shape_count > 0:
                 force_records += 1
             particle_deterministic_max_records = max(truncation_records, force_records)
+            coupling_deterministic_max_records = 2 * edge_iterations + 3 * vertex_iterations
         if model.particle_count > 0:
             self._set_module_options(
                 {
@@ -399,6 +401,13 @@ class SolverVBD(SolverBase, CouplingInterface):
                 },
                 module=particle_vbd_kernels,
             )
+        self._set_module_options(
+            {
+                "deterministic": effective_deterministic,
+                "deterministic_max_records": coupling_deterministic_max_records,
+            },
+            module=vbd_coupling_kernels,
+        )
 
         options = {"deterministic": effective_deterministic, "deterministic_max_records": 0}
         if model.body_count > 0 and not integrate_with_external_rigid_solver:
@@ -817,6 +826,7 @@ class SolverVBD(SolverBase, CouplingInterface):
         dt: float = 0.0,
     ) -> None:
         """Convert input body pose updates into VBD-compatible history updates."""
+        self._apply_module_options()
         flags = int(flags)
 
         if (
@@ -886,6 +896,7 @@ class SolverVBD(SolverBase, CouplingInterface):
         coupling interface, so VBD harvests explicit contact forces instead of
         inferring feedback from total proxy momentum change.
         """
+        self._apply_module_options()
         if not self._coupling_has_rigid_avbd_state:
             super().coupling_harvest_proxy_wrenches(
                 body_local_to_proxy_global,
@@ -981,6 +992,7 @@ class SolverVBD(SolverBase, CouplingInterface):
         coupling, but those proxy-only interactions should not appear as
         feedback forces on the source side.
         """
+        self._apply_module_options()
         del particle_qd_before
         out_particle_f.zero_()
         if self.model.particle_count == 0 or particle_local_to_proxy_global.shape[0] == 0:

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -114,6 +114,14 @@ class SolverXPBD(SolverBase, CouplingInterface):
         enable_restitution: bool = False,
         deterministic: wp.DeterministicMode | None = None,
     ):
+        """Initialize the solver.
+
+        Args:
+            deterministic: Opt-in determinism for this solver's atomic-emitting
+                kernel module. Pass a :class:`warp.DeterministicMode`, or
+                ``None`` (default) to inherit the current
+                ``wp.config.deterministic`` mode.
+        """
         super().__init__(model=model)
         effective_deterministic = deterministic if deterministic is not None else wp.config.deterministic
         self._set_module_options(

--- a/newton/tests/determinism/test_solver_determinism.py
+++ b/newton/tests/determinism/test_solver_determinism.py
@@ -12,7 +12,7 @@ import warp as wp
 import newton
 from newton._src.solvers.semi_implicit import kernels_particle as semi_implicit_particle_kernels
 from newton._src.solvers.solver import _set_module_options_if_changed
-from newton._src.solvers.vbd import particle_vbd_kernels
+from newton._src.solvers.vbd import particle_vbd_kernels, vbd_coupling_kernels
 from newton._src.solvers.xpbd import kernels as xpbd_kernels
 from newton.tests.unittest_utils import add_function_test, get_cuda_test_devices
 
@@ -191,7 +191,12 @@ class TestSolverDeterminism(unittest.TestCase):
 
 class TestSolverDeterminismOptions(unittest.TestCase):
     def setUp(self):
-        self._modules = (xpbd_kernels, particle_vbd_kernels, semi_implicit_particle_kernels)
+        self._modules = (
+            xpbd_kernels,
+            particle_vbd_kernels,
+            semi_implicit_particle_kernels,
+            vbd_coupling_kernels,
+        )
         self._saved_config = wp.config.deterministic
         self._saved_options = {
             module: {
@@ -327,6 +332,36 @@ class TestSolverDeterminismOptions(unittest.TestCase):
             options = wp.get_module_options(module=particle_vbd_kernels)
             self.assertEqual(options["deterministic"], wp.DeterministicMode.NOT_GUARANTEED)
             self.assertEqual(options["deterministic_max_records"], 0)
+
+    def test_vbd_coupling_hook_reapplies_deterministic_options(self):
+        with wp.ScopedDevice("cpu"):
+            model = _build_soft_body("cpu")
+            deterministic_solver = newton.solvers.SolverVBD(
+                model,
+                particle_enable_self_contact=True,
+                particle_enable_tile_solve=False,
+                particle_vertex_contact_buffer_size=64,
+                particle_edge_contact_buffer_size=64,
+                deterministic=DETERMINISTIC_MODE,
+            )
+            newton.solvers.SolverVBD(
+                model,
+                particle_enable_self_contact=False,
+                particle_enable_tile_solve=False,
+                deterministic=wp.DeterministicMode.NOT_GUARANTEED,
+            )
+
+            deterministic_solver.coupling_notify_input_state_update(
+                model.state(),
+                newton.StateFlags.BODY_Q,
+            )
+
+            options = wp.get_module_options(module=vbd_coupling_kernels)
+            records_per_buffer = (64 + particle_vbd_kernels.NUM_THREADS_PER_COLLISION_PRIMITIVE - 1) // (
+                particle_vbd_kernels.NUM_THREADS_PER_COLLISION_PRIMITIVE
+            )
+            self.assertEqual(options["deterministic"], DETERMINISTIC_MODE)
+            self.assertEqual(options["deterministic_max_records"], 5 * records_per_buffer)
 
 
 devices = get_cuda_test_devices(mode="basic")

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -112,6 +112,34 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
 
 
 class TestMuJoCoDeterminismConfig(unittest.TestCase):
+    def test_loaded_modules_keep_codegen_record_bound(self):
+        solver = object.__new__(solver_mujoco.SolverMuJoCo)
+        solver._deterministic = solver_mujoco.wp.DeterministicMode.RUN_TO_RUN
+        solver._deterministic_max_records = 17
+        loaded_module = object()
+
+        with (
+            mock.patch.object(
+                solver_mujoco,
+                "_mujoco_warp_deterministic_modules",
+                return_value=[loaded_module],
+            ),
+            mock.patch.object(solver, "_set_module_options") as set_module_options,
+        ):
+            solver._set_mujoco_warp_module_options()
+
+        options = {
+            "deterministic": solver_mujoco.wp.DeterministicMode.RUN_TO_RUN,
+            "deterministic_max_records": 0,
+        }
+        self.assertEqual(
+            set_module_options.call_args_list,
+            [
+                mock.call(options, module=loaded_module),
+                mock.call(options, module=solver_mujoco.kernels),
+            ],
+        )
+
     def test_scoped_config_uses_solver_mode_and_restores_globals(self):
         solver = object.__new__(solver_mujoco.SolverMuJoCo)
         solver._deterministic = solver_mujoco.wp.DeterministicMode.NOT_GUARANTEED
@@ -131,6 +159,46 @@ class TestMuJoCoDeterminismConfig(unittest.TestCase):
 
             self.assertEqual(solver_mujoco.wp.config.deterministic, solver_mujoco.wp.DeterministicMode.RUN_TO_RUN)
             self.assertEqual(solver_mujoco.wp.config.deterministic_max_records, 17)
+        finally:
+            solver_mujoco.wp.config.deterministic = original_mode
+            solver_mujoco.wp.config.deterministic_max_records = original_max_records
+
+    def test_notify_model_changed_uses_solver_config_for_mjwarp(self):
+        solver = object.__new__(solver_mujoco.SolverMuJoCo)
+        solver.use_mujoco_cpu = False
+        solver._deterministic = solver_mujoco.wp.DeterministicMode.RUN_TO_RUN
+        solver._deterministic_max_records = 17
+        solver.has_connect_constraints = False
+        solver.has_jnt_connect_constraints = False
+        observed_options = []
+
+        def observe_options():
+            observed_options.append(
+                (
+                    solver_mujoco.wp.config.deterministic,
+                    solver_mujoco.wp.config.deterministic_max_records,
+                )
+            )
+
+        original_mode = solver_mujoco.wp.config.deterministic
+        original_max_records = solver_mujoco.wp.config.deterministic_max_records
+        try:
+            solver_mujoco.wp.config.deterministic = solver_mujoco.wp.DeterministicMode.NOT_GUARANTEED
+            solver_mujoco.wp.config.deterministic_max_records = 0
+            with (
+                mock.patch.object(solver, "_apply_module_options") as apply_module_options,
+                mock.patch.object(solver, "_prepare_generated_kernels") as prepare_generated_kernels,
+                mock.patch.object(solver, "_update_model_properties", side_effect=observe_options),
+                mock.patch.object(solver, "_invalidate_contact_fast_path"),
+            ):
+                solver.notify_model_changed(solver_mujoco.ModelFlags.MODEL_PROPERTIES)
+
+            apply_module_options.assert_called_once_with()
+            prepare_generated_kernels.assert_called_once_with()
+            self.assertEqual(
+                observed_options,
+                [(solver_mujoco.wp.DeterministicMode.RUN_TO_RUN, 17)],
+            )
         finally:
             solver_mujoco.wp.config.deterministic = original_mode
             solver_mujoco.wp.config.deterministic_max_records = original_max_records


### PR DESCRIPTION
## Description

Fix the deterministic-solver review findings from newton-physics/newton#3300.

- Keep model-derived deterministic record bounds limited to lazily generated
  MJWarp kernels; loaded shared modules continue using Warp's code-generated
  static bounds.
- Apply solver-local MJWarp compilation options while stepping and while model
  notifications can create generated kernels.
- Configure VBD coupling kernels, including a bound for dynamic self-contact
  force harvesting, and reapply their options from public coupling hooks.
- Document the new `SolverXPBD.deterministic` constructor argument.

This addresses the constructor-time generated-kernel cache issue, batched
MuJoCo record overallocation, and coupled-VBD determinism gaps raised in the
parent PR review.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (the parent branch already contains the
      user-facing determinism entry)

## Test plan

```bash
uv run --extra dev -m unittest -v \
  newton.tests.determinism.test_solver_determinism.TestSolverDeterminismOptions \
  newton.tests.test_mujoco_version_check.TestMuJoCoDeterminismConfig
uv run --extra dev -m newton.tests -k test_solver_determinism
uv run --extra dev -m unittest -v \
  newton.tests.test_mujoco_version_check \
  newton.tests.test_api
uv run --extra dev -m unittest -v \
  newton.tests.test_coupled_solver.TestSolverMuJoCoCouplingHooks \
  newton.tests.test_coupled_solver.TestSolverVBDCouplingHooks
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Construct a deterministic MuJoCo solver whose model refresh creates a
   generated MJWarp kernel, or construct a batched solver with a large
   `njmax`.
2. Alternatively, alternate coupled VBD solvers with different deterministic
   modes and invoke a public coupling hook.
3. Observe generated kernels using the process-global mode, shared MJWarp
   modules inheriting the large dynamic-loop record bound, or VBD coupling
   kernels retaining the other solver's mode.

The added regressions exercise these configuration seams without relying on a
flaky assertion that `NOT_GUARANTEED` runs must diverge.
